### PR TITLE
chore: upgrade Symfony packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,15 +15,15 @@
     ],
     "require": {
         "php": ">=8.0",
-        "symfony/http-kernel": "^5.4|^6.0",
-        "symfony/console": "^5.4|^6.0",
+        "symfony/http-kernel": "^6.4|^7.0",
+        "symfony/console": "^6.4|^7.0",
         "doctrine/doctrine-bundle": "^2.5",
         "doctrine/orm": "^2.10",
-        "symfony/uid": "^5.4|^6.0"
+        "symfony/uid": "^6.4|^7.0"
     },
     "require-dev": {
         "pestphp/pest": "^1.21",
-        "symfony/yaml": "^5.4|^6.0"
+        "symfony/yaml": "^6.4|^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Accept only `6.4` and `7.0` and higher.