### PR TITLE
build: upgrade to PHP 8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - 8.2
           - 8.3
         experimental: [false]
         include:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ to prune Doctrine entities that you consider stale.
 
 ## Installation
 
-PHP 8.2 or above is required.
+PHP 8.3 or above is required.
 
 ```bash
 composer require geonative/garbage-collector

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.3",
         "symfony/http-kernel": "^6.4|^7.0",
         "symfony/console": "^6.4|^7.0",
         "doctrine/doctrine-bundle": "^2.5",


### PR DESCRIPTION
PHP `8.3` is now the default version instead of PHP `8.2`.

Tests on PHP `8.4` (experimental one) do not work because of version of Pest. Another PR will fix it.