### PR TITLE
ci: upgrade version of Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:


### PR DESCRIPTION
Related PR:
- https://github.com/geonativefr/geonative-api/pull/1169

To Ubuntu `24.04` (LTS).