### PR TITLE
chore: upgrade packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,15 +15,15 @@
     ],
     "require": {
         "php": ">=8.3",
-        "symfony/http-kernel": "^6.4|^7.0",
-        "symfony/console": "^6.4|^7.0",
+        "symfony/http-kernel": "^7.4 || ^8.0",
+        "symfony/console": "^7.4 || ^8.0",
         "doctrine/doctrine-bundle": "^2.5",
         "doctrine/orm": "^2.10",
-        "symfony/uid": "^6.4|^7.0"
+        "symfony/uid": "^7.4 || ^8.0"
     },
     "require-dev": {
-        "pestphp/pest": "^2.36",
-        "symfony/yaml": "^6.4|^7.0"
+        "pestphp/pest": "^4.3",
+        "symfony/yaml": "^7.4 || ^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR upgrades packages:
- `"symfony/http-kernel": "^7.4 || ^8.0"`: manage the last versions of Symfony
- `"symfony/console": "^7.4 || ^8.0"`: manage the last versions of Symfony
- `"symfony/uid": "^7.4 || ^8.0"`: manage the last versions of Symfony
- `"symfony/yaml": "^7.4 || ^8.0"`: manage the last versions of Symfony
- `"pestphp/pest": "^4.3"`: last version