### PR TITLE
build: upgrade to PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - 8.3
           - 8.4
           - 8.5
         experimental: [false]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ to prune Doctrine entities that you consider stale.
 
 ## Installation
 
-PHP 8.3 or above is required.
+PHP 8.4 or above is required.
 
 ```bash
 composer require geonative/garbage-collector

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=8.3",
+        "php": ">=8.4",
         "symfony/http-kernel": "^7.4 || ^8.0",
         "symfony/console": "^7.4 || ^8.0",
         "doctrine/doctrine-bundle": "^2.5",


### PR DESCRIPTION
PHP `8.4` is now the default version instead of PHP `8.3`.